### PR TITLE
Format logs and add manual option to start llama server

### DIFF
--- a/src/botex/bot.py
+++ b/src/botex/bot.py
@@ -207,7 +207,7 @@ def run_bot(
             if error:
                 append_message_to_conversation({"role": "user", "content": message})
                 logging.info(
-                    f"Sending the following conversation to the llm to fix error: {conversation}"
+                    f"Sending the following conversation to the llm to fix error:\n{json.dumps(conversation, indent=4)}"
                 )
             if model == "local":
                 assert local_llm, "Model is local but local_llm is not set."
@@ -233,7 +233,7 @@ def run_bot(
                 resp_str = resp_str[start:end+1]
                 resp_dict = json.loads(resp_str, strict = False)
             except (AssertionError, json.JSONDecodeError):
-                logging.warning(f"Bot's response is not a valid JSON\n{resp_str}\n. Trying again.")
+                logging.warning("Bot's response is not a valid JSON.")
                 resp_dict = None
                 error = True
                 message = prompts['json_error']
@@ -252,7 +252,7 @@ def run_bot(
                     success, error_msgs, error_logs = check_response(resp_dict)
                 if not success:
                     error = True
-                    logging.warning(f"Detected an issue: {' '.join(error_logs)}.\n{resp_dict}.\nAdjusting response.")
+                    logging.warning(f"Detected an issue: {' '.join(error_logs)}.")
                     message = ''
                     for i, error_msg in enumerate(error_msgs):
                         if ':' in error_msg:
@@ -501,7 +501,7 @@ def run_bot(
     if resp == 'Maximum number of attempts reached.':
         gracefully_exit_failed_bot("start")
         return
-    logging.info(f"Bot's response to start message: '{resp}'")
+    logging.info(f"Bot's response to start message:\n{json.dumps(resp, indent=4)}")
     
     options = Options()
     options.add_argument("--headless=new")
@@ -597,7 +597,7 @@ def run_bot(
             gracefully_exit_failed_bot("middle")
             return
 
-        logging.info(f"Bot analysis of page: '{resp}'")
+        logging.info(f"Bot's analysis of page:\n{json.dumps(resp, indent=4)}")
         if not full_conv_history: summary = resp['summary']
         if questions is None and next_button is not None:
             logging.info("Page has no question but next button. Clicking")
@@ -647,7 +647,7 @@ def run_bot(
     if resp == 'Maximum number of attempts reached.':
         gracefully_exit_failed_bot("end")
         return
-    logging.info(f"Bot's final remarks about experiment: '{resp}'")
+    logging.info(f"Bot's final remarks about experiment:\n{json.dumps(resp, indent=4)}")
     logging.info("Bot finished.")
     store_data(botex_db, session_id, url, conv_hist_botex_db, bot_parms)
 

--- a/src/botex/local_llm.py
+++ b/src/botex/local_llm.py
@@ -31,6 +31,7 @@ class LocalLLM:
     Parameters:
     path_to_llama_server (str): The path to the llama cpp server executable.
     local_llm_path (str): The path to the local language model.
+    start_llama_server (bool): Whether to start the llama cpp server, defaults to True. If False, the program will not start the server and will expect the server to be started manually by the user.
     api_base_url (str): The base URL for the llama cpp server.
     context_length (int): The context length for the model, defaults to None.
         If None, the program will try to get the context length from the local
@@ -45,6 +46,7 @@ class LocalLLM:
         self,
         path_to_llama_server: str,
         local_llm_path: str,
+        start_llama_server: bool = True,
         api_base_url: str = "http://localhost:8080",
         context_length: int | None = None,
         number_of_layers_to_offload_to_gpu: int = 1,
@@ -57,6 +59,7 @@ class LocalLLM:
     ):
         self.server_path = path_to_llama_server
         self.model_path = local_llm_path
+        self.start_llama_server = start_llama_server
         self.api_base_url = api_base_url
         parsed_gguf = GGUFParser(self.model_path)
         self.metadata = parsed_gguf.get_metadata()
@@ -82,6 +85,9 @@ class LocalLLM:
         """
         Starts the local language model server.
         """
+        if not self.start_llama_server:
+            logging.info("You have chosen to manually start the LLM server. Please make sure that llama_server is up and running on %s", self.api_base_url)
+            return
         self.validate_parameters()
 
         parsed_url = urlparse(self.api_base_url)
@@ -155,6 +161,9 @@ class LocalLLM:
         """
         Stops the local language model server.
         """
+        if not self.start_llama_server:
+            logging.info("The LLM server is started manually. Please stop it manually as well.")
+            return
         if process:
             logging.info("Stopping server...")
             parent = psutil.Process(process.pid)

--- a/src/botex/local_llm.py
+++ b/src/botex/local_llm.py
@@ -85,12 +85,15 @@ class LocalLLM:
         """
         Starts the local language model server.
         """
+        parsed_url = urlparse(self.api_base_url)
         if not self.start_llama_server:
-            logging.info("You have chosen to manually start the LLM server. Please make sure that llama_server is up and running on %s", self.api_base_url)
+            if self.wait_for_server(parsed_url.hostname, parsed_url.port):
+                logging.info("You have chosen to manually start the LLM server. LLM server is running on %s. Make sure this is what you intended", self.api_base_url)
+            else:
+                raise Exception(f"You have chosen to manually start the LLM server. But the server is not running on api_base_url: {self.api_base_url}. Please make sure that llama_server is up and running on api_base_url: {self.api_base_url}")
             return
         self.validate_parameters()
 
-        parsed_url = urlparse(self.api_base_url)
         cmd = [
             self.server_path,
             "--host",

--- a/src/botex/otree.py
+++ b/src/botex/otree.py
@@ -282,7 +282,7 @@ def run_bots_on_session(
     if wait: 
         for t in threads: t.join()
     
-    if local_llm:
+    if local_llm and local_llm.start_llama_server:
         assert llm_server, "Local LLM server not started, but should have been."
         local_llm.stop_server(llm_server)
 

--- a/tests/test_c_local_llm.py
+++ b/tests/test_c_local_llm.py
@@ -15,6 +15,8 @@ with open("secrets.env") as f:
             continue
         key, value = line.strip().split("=")
         cfg[key] = value.strip('\"\'')
+        if key == "start_llama_server":
+            cfg[key] = eval(cfg[key])
     cfg = {k.lower(): v for k, v in cfg.items()}
 
 @pytest.mark.dependency(name="llama_server_executable", scope='session')


### PR DESCRIPTION
I format the logs and remove redundant logs (related to error correction as we just log the whole conversation before error correction) and I have added the manual option for the llama server with a check that it is actually running.